### PR TITLE
Remove usage of flask_api HTTP constants and fix versions of requirements.

### DIFF
--- a/ctt-agent.py
+++ b/ctt-agent.py
@@ -6,15 +6,17 @@ import os
 
 # Module imports
 from flask import Flask
-from flask_api import status
 from straight.plugin.loaders import ModuleLoader
+from waitress import serve
+
 
 logging.basicConfig(level=logging.INFO)
 
-base_path = '/tmp/radon-ctt-agent'
+base_path = '/opt/radon-ctt-agent'
 
 
 def register_plugins(plugin_list):
+    logging.info(f'Found {len(plugin_list)} plugins.')
     for plugin in plugin_list:
         if plugin.storage_enabled:
             plugin_path = os.path.join(base_path, plugin.prefix)
@@ -22,6 +24,8 @@ def register_plugins(plugin_list):
             plugin.register(app, plugin_path)
         else:
             plugin.register(app)
+
+        logging.info(f'> Plugin {plugin} registered')
 
 
 app = Flask(__name__)
@@ -32,8 +36,8 @@ register_plugins(plugins)
 
 @app.route('/')
 def index():
-    return f'This is the Radon Continuous Testing Tool (CTT) Agent.', status.HTTP_200_OK
+    return f'This is the Radon Continuous Testing Tool (CTT) Agent.', 200
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0')
+    serve(app=app, host="0.0.0.0", port=5000)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-flask
-flask_api
-straight.plugin
+flask==2.0.0
+straight.plugin==1.5.0
+waitress==2.0.0


### PR DESCRIPTION
Resolves radon-h2020/radon-ctt#99 for `radon-ctt-agent`.